### PR TITLE
Solve fiona package not import issue

### DIFF
--- a/0_Taxi.ipynb
+++ b/0_Taxi.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!conda install -c conda-forge cartopy -y"
+    "!conda install -c conda-forge cartopy -y -q"
    ]
   },
   {
@@ -40,6 +40,15 @@
    "outputs": [],
    "source": [
     "!pip install descartes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda install -c conda-forge geopandas -y"
    ]
   },
   {

--- a/0_Taxi.ipynb
+++ b/0_Taxi.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!conda install -c conda-forge geopandas -y"
+    "!conda install -c conda-forge geopandas -y -q"
    ]
   },
   {


### PR DESCRIPTION
- Solve fiona package not import issue by installing geopandas
- Add -q flag to supress long output generation when installing packages